### PR TITLE
docs: update links to new repository home

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 This repo enables using the Virtuoso Design System as front-end code (HTML, CSS, & JavaScript).
 
-[Dive into the docs.](https://avkvirtru.github.io/virtuoso-design-system/)
+# 📖 [Dive into the docs](https://virtru.github.io/virtuoso-design-system/)
+
+# 🤖 [Explore the code](https://github.com/virtru/virtuoso-design-system)
 
 ## Docs
 
-The documentation for Virtuoso is [hosted on GitHub Pages](https://avkvirtru.github.io/virtuoso-design-system/) and powered by [Storybook](https://storybook.js.org). 
+The documentation for Virtuoso is [hosted on GitHub Pages](https://virtru.github.io/virtuoso-design-system/) and powered by [Storybook](https://storybook.js.org). 
 
 To run storybook locally:
 

--- a/examples/simple-app/README.md
+++ b/examples/simple-app/README.md
@@ -16,4 +16,4 @@ npm start
 
 *Step 2*
 
-Check out the variety of components supported through the [Virtuoso Design System Storybook](avkvirtru.github.io/virtuoso-design-system/) and start adding them to your app!
+Check out the variety of components supported through the [Virtuoso Design System Storybook](virtru.github.io/virtuoso-design-system/) and start adding them to your app!

--- a/examples/simple-app/index.css
+++ b/examples/simple-app/index.css
@@ -1,6 +1,6 @@
 /*  
  * Example styles using Virtuoso Design System (e.g. `var(--vds-*)`)
- * https://avkvirtru.github.io/virtuoso-design-system/?path=/docs/basics-design-tokens--page
+ * https://virtru.github.io/virtuoso-design-system/?path=/docs/basics-design-tokens--page
  */
  
 html {

--- a/stories/Intro-design-tokens.stories.mdx
+++ b/stories/Intro-design-tokens.stories.mdx
@@ -14,11 +14,11 @@ import cssDesignTokens from '!!raw-loader!@/styles/build/css/design_tokens.css';
 
 [Style Dictionary](https://amzn.github.io/style-dictionary/#/) is a build system that allows you to define **design tokens** once, in a way for any platform or language to consume. 
 
-1. Our design tokens are defined in [lib/styles/style_dict/tokens/](https://github.com/avkvirtru/virtuoso-design-system/blob/master/lib/styles/style_dict/tokens/) as JSON files…
+1. Our design tokens are defined in [lib/styles/style_dict/tokens/](https://github.com/virtru/virtuoso-design-system/blob/master/lib/styles/style_dict/tokens/) as JSON files…
 
 1. …built into the versions below.
 
-Design tokens change **INFREQUENTLY**. So building them is a manual step that should be code reviewed. See [GitHub README](https://github.com/avkvirtru/virtuoso-design-system/blob/master/README.md) for the details.
+Design tokens change **INFREQUENTLY**. So building them is a manual step that should be code reviewed. See [GitHub README](https://github.com/virtru/virtuoso-design-system/blob/master/README.md) for the details.
 
 ## Governance
 


### PR DESCRIPTION
We've transferred the repository to @virtru 

- Old URL: https://github.com/avkvirtru/virtuoso-design-system
- New URL: https://github.com/virtru/virtuoso-design-system

But since GitHub Pages [**don't** automatically redirect](https://docs.github.com/en/github/administering-a-repository/transferring-a-repository), this updates links to the new documentation home.

### Checklist

- [x] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

Should we update the repo links in `CHANGELOG.md`?
