### PR TITLE
fix(helpers:expand-children): use displayName property to prevent mangling with minimization

### DIFF
--- a/lib/components/Layout/Footer.js
+++ b/lib/components/Layout/Footer.js
@@ -7,4 +7,6 @@ function Footer() {
   return <footer>Footer here</footer>;
 }
 
+Footer.displayName = 'Footer';
+
 export default Footer;

--- a/lib/components/Layout/Header.js
+++ b/lib/components/Layout/Header.js
@@ -26,6 +26,8 @@ function Branding({ logo, company }) {
   );
 }
 
+Branding.displayName = 'Branding';
+
 Branding.propTypes = {
   company: PropTypes.string,
   logo: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
@@ -58,6 +60,8 @@ function Header({ children, company, logo, title }) {
     </div>
   );
 }
+
+Header.displayName = 'Header';
 
 Header.propTypes = {
   logo: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),

--- a/lib/helpers/expandChildren.js
+++ b/lib/helpers/expandChildren.js
@@ -1,12 +1,15 @@
 import { Children } from 'react';
 
 /**
- * Expand react children from an array of children
+ * Expand children for an enhanced component API
  *
- * In order to create a very usable component API a pattern like `<List><List.Item /></List>` is very useful. To enhance
- * the implementation this helper will take in an array of children and an array of components which you want expanded.
+ * **NOTE: You must add the `displayName` property to your component or code minification will break this feature.**
+ *
+ * This utility helps in the process of developing enhanced component APIs where you add specific components as children
+ * and not render them with the rest of the children. This is useful to utilize components as flags or distinct structures.
  *
  * @example
+ * ```jsx
  * // Given some component implementation
  * <List>
  *   Content after list 1
@@ -15,9 +18,12 @@ import { Children } from 'react';
  *   <List.Item>Two</List.Item>
  *   Content after list 3
  * </List>
+ * ```
  *
+ * ```jsx
  * // Extract the Items from the children
  * const Item = ({ children }) => (<li>{children}</li>);
+ * Item.displayName = 'Item';
  *
  * const List = ({ children }) => {
  *   const [ nextChildren, { Item: itemChildren } ] = expandChildren(children, [ Item ]);
@@ -30,8 +36,10 @@ import { Children } from 'react';
  * }
  *
  * List.Item = Item;
+ * ```
  *
- * // Renders as
+ * ```html
+ * <!-- Renders as -->
  * <div>
  *   <ul>
  *     <li>One</li>
@@ -41,6 +49,7 @@ import { Children } from 'react';
  *   Content after list 2
  *   Content after list 3
  * </div>
+ * ```
  *
  * @param {array} children children
  * @param {array} childrenToExpand Children which will be ex
@@ -55,14 +64,17 @@ export default function expandChildren(children, childrenToExpand) {
   const nextChildren = [];
   const expandedChildren = {};
   Children.forEach(children, (child) => {
-    const childType = childrenToExpand.find((type) => child.type === type);
+    const childType = childrenToExpand.find((model) => {
+      return (
+        model && model.displayName && child.type && child.type.displayName === model.displayName
+      );
+    });
     if (childType) {
-      if (!expandedChildren[childType.name]) expandedChildren[childType.name] = [];
-      expandedChildren[childType.name].push(child);
+      if (!expandedChildren[childType.displayName]) expandedChildren[childType.displayName] = [];
+      expandedChildren[childType.displayName].push(child);
     } else {
       nextChildren.push(child);
     }
-    return child;
   });
   return [nextChildren, expandedChildren];
 }

--- a/lib/helpers/expandChildren.test.js
+++ b/lib/helpers/expandChildren.test.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { expandChildren } from '@/helpers';
 
-// A simple component to use to test expanding children
 // eslint-disable-next-line require-jsdoc
 function ExpandChild() {}
+ExpandChild.displayName = 'ExpandChild';
 
 test('should return an errors', () => {
   expect(() => expandChildren()).toThrowError();
@@ -33,5 +33,14 @@ test('should expand all children', () => {
   expect(expandChildren([ChildOne, ChildTwo], [ExpandChild])).toEqual([
     [],
     { ExpandChild: [ChildOne, ChildTwo] },
+  ]);
+});
+
+test('should not expand children that do not have a displayName property', () => {
+  const ChildOne = <ExpandChild />;
+  const ChildTwo = <Component />;
+  expect(expandChildren([ChildOne, ChildTwo], [ExpandChild, Component])).toEqual([
+    [ChildTwo],
+    { ExpandChild: [ChildOne] },
   ]);
 });


### PR DESCRIPTION
fix(helpers:expand-children): use displayName property to prevent mangling with minimization