### PR TITLE
feat(design tokens): add font weight tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage
 .storybook-out/
 lefthook-local.yml
 report.*.json
+examples/simple-app/design_tokens+local.css

--- a/examples/simple-app/index.css
+++ b/examples/simple-app/index.css
@@ -49,3 +49,7 @@ li {
 
 .ex__body--md { font: var(--vds-font-md); }
 .ex__body--sm { font: var(--vds-font-sm); }
+
+.ex__body--regular-weight { font-weight: var(--vds-font-weight-regular); }
+.ex__body--semibold-weight { font-weight: var(--vds-font-weight-semibold); }
+.ex__body--bold-weight { font-weight: var(--vds-font-weight-bold); }

--- a/examples/simple-app/index.html
+++ b/examples/simple-app/index.html
@@ -24,6 +24,11 @@
       href="https://unpkg.com/virtuoso-design-system@latest/dist/base.css">
     -->
     
+    <!-- OPTIONAL: load unreleased version for development -->
+    <link 
+      rel="stylesheet" 
+      href="./design_tokens+local.css">
+    
     <!-- why? styles for this example app -->
     <link rel="stylesheet" href="index.css">
   </head>

--- a/examples/simple-app/index.js
+++ b/examples/simple-app/index.js
@@ -37,6 +37,11 @@ function SimpleApp() {
 
         <p className="ex__body--md">Body copy</p>
         <small className="ex__body--sm">Small text</small>
+        
+        <hr />  
+        <p className="ex__body--md ex__body--regular-weight">Regular weight</p>
+        <p className="ex__body--md ex__body--semibold-weight">Semibold weight</p>
+        <p className="ex__body--md ex__body--bold-weight">Bold weight</p>
       </section>
     </Layout>
   );

--- a/lib/styles/build/css/design_tokens.css
+++ b/lib/styles/build/css/design_tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 13 Aug 2020 21:49:49 GMT
+ * Generated on Mon, 28 Sep 2020 18:08:45 GMT
  */
 
 :root {
@@ -81,6 +81,10 @@
   --vds-font-size-heading-md: calc(var(--vds-font-size-heading-sm) * var(--vds-font-scale-multiplier)); /* 31/36px !!! consider --vds-font-* to set all font properties, not just font-size */
   --vds-font-size-heading-lg: calc(var(--vds-font-size-heading-md) * var(--vds-font-scale-multiplier)); /* 39/48px !!! consider --vds-font-* to set all font properties, not just font-size */
   --vds-font-size-heading-xl: calc(var(--vds-font-size-heading-lg) * var(--vds-font-scale-multiplier)); /* 49/54px !!! consider --vds-font-* to set all font properties, not just font-size */
+  --vds-font-weight-regular: 400;
+  --vds-font-weight-normal: var(--vds-font-weight-regular);
+  --vds-font-weight-semibold: 600;
+  --vds-font-weight-bold: 700;
   --vds-line-height-xxs: 1.50; /* 8/12px !!! consider --vds-font-* to set all font properties, not just line-height */
   --vds-line-height-xs: 1.50; /* 10/15px !!! consider --vds-font-* to set all font properties, not just line-height */
   --vds-line-height-sm: 1.38; /* 13/18px !!! consider --vds-font-* to set all font properties, not just line-height */

--- a/lib/styles/build/js/design_tokens.js
+++ b/lib/styles/build/js/design_tokens.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 13 Aug 2020 21:50:01 GMT
+ * Generated on Mon, 28 Sep 2020 18:08:57 GMT
  */
 
 module.exports = {
@@ -1478,6 +1478,84 @@ module.exports = {
             "font",
             "size",
             "heading-xl"
+          ]
+        }
+      },
+      "weight": {
+        "regular": {
+          "value": "400",
+          "original": {
+            "value": "400"
+          },
+          "name": "VdsFontWeightRegular",
+          "attributes": {
+            "category": "vds",
+            "type": "font",
+            "item": "weight",
+            "subitem": "regular"
+          },
+          "path": [
+            "vds",
+            "font",
+            "weight",
+            "regular"
+          ]
+        },
+        "normal": {
+          "value": "400",
+          "original": {
+            "value": "{vds.font.weight.regular.value}"
+          },
+          "name": "VdsFontWeightNormal",
+          "attributes": {
+            "category": "vds",
+            "type": "font",
+            "item": "weight",
+            "subitem": "normal"
+          },
+          "path": [
+            "vds",
+            "font",
+            "weight",
+            "normal"
+          ]
+        },
+        "semibold": {
+          "value": "600",
+          "original": {
+            "value": "600"
+          },
+          "name": "VdsFontWeightSemibold",
+          "attributes": {
+            "category": "vds",
+            "type": "font",
+            "item": "weight",
+            "subitem": "semibold"
+          },
+          "path": [
+            "vds",
+            "font",
+            "weight",
+            "semibold"
+          ]
+        },
+        "bold": {
+          "value": "700",
+          "original": {
+            "value": "700"
+          },
+          "name": "VdsFontWeightBold",
+          "attributes": {
+            "category": "vds",
+            "type": "font",
+            "item": "weight",
+            "subitem": "bold"
+          },
+          "path": [
+            "vds",
+            "font",
+            "weight",
+            "bold"
           ]
         }
       }

--- a/lib/styles/style_dict/config.js
+++ b/lib/styles/style_dict/config.js
@@ -63,6 +63,8 @@ StyleDictionary.registerTransformGroup({
 module.exports = {
   "source": ["lib/styles/style_dict/tokens/**/*.json"],
   "platforms": {
+    
+    // why? production CSS
     "css": {
       "transformGroup": "css-vds", 
       "buildPath": "lib/styles/build/css/",
@@ -71,6 +73,18 @@ module.exports = {
         "format": "css/variables"
       }]
     },
+    
+    // why? CSS for local testing in example app
+    "css+local": {
+      "transformGroup": "css-vds", 
+      "buildPath": "examples/simple-app/",
+      "files": [{
+        "destination": "design_tokens+local.css",
+        "format": "css/variables"
+      }]
+    },
+
+    // why? production JS
     "js": {
       "transformGroup": "js",
       "buildPath": "lib/styles/build/js/",

--- a/lib/styles/style_dict/tokens/font/weights.json
+++ b/lib/styles/style_dict/tokens/font/weights.json
@@ -1,0 +1,12 @@
+{
+  "vds": {
+    "font": {
+      "weight": {
+        "regular":  { "value": "400" },
+        "normal":   { "value": "{vds.font.weight.regular.value}" },
+        "semibold": { "value": "600" },
+        "bold":     { "value": "700" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Proposed Changes

1. addresses #83 using [unambiguous font-weight values](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/44370126/94469926-bee1b400-017b-11eb-9496-f5dc037c2027.png">

2. allows design tokens to be built for sample app (worth [running locally](http://localhost:1234) to test, see below).


### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors

### Testing Instructions

1. pull down this branch
1. `npm run style-dictionary:build`
1. You should see a new style token file `examples/simple-app/design_tokens+local.css`
1. `cd examples/simple-app`
1. `npm i && npm start`
1. open [localhost:1234](http://localhost:1234/) to see new font weights in use at the bottom of the page

<img width="1792" alt="Screen Shot 2020-09-28 at 11 14 44 AM" src="https://user-images.githubusercontent.com/44370126/94470062-f3ee0680-017b-11eb-972e-a29cacb70e4b.png">
