### PR TITLE
CCR-98 Use use '[hash:base64]' classnames for production

### DIFF
--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -5,7 +5,8 @@ const postcssCustomProperties = require('postcss-custom-properties');
 const postcssCustomMedia = require('postcss-custom-media');
 
 module.exports = {
-  modules: true,
+  autoModules: false,
+  modules: { generateScopedName: '[hash:base64]' },
   plugins: [
     postcssImport(),
     postcssCustomProperties({


### PR DESCRIPTION
### Proposed Changes
* Use use `[hash:base64]` css class names for production as suggested [here](https://webpack.js.org/loaders/css-loader/#localidentname)
This is needed because previously we had the same class names as in `react-components` which made conflicts and override styles

- CCR-98
  - Use base64 for css class name in production

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
