### PR TITLE
fix: use color for chart slice testid selector

### DIFF
--- a/lib/components/PieChart/components/ArcsLayer/ArcsLayer.js
+++ b/lib/components/PieChart/components/ArcsLayer/ArcsLayer.js
@@ -35,7 +35,7 @@ const ArcsLayer = ({ radius, innerRadius, dataWithArc, centerX, centerY }) => {
             className={styles.slice}
             d={currentArcGenerator(arcData)}
             fill={d.color}
-            data-testid={`VDS-chart-slice-${d.value}`}
+            data-testid={`VDS-chart-slice-${d.color}`}
             onClick={(event) => onItemClick(d.data, event)}
           />
         );


### PR DESCRIPTION
### Proposed Changes
Fix selector added to chart to key off its color hex value and not whatever data value it has

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
