### PR TITLE
doc: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-_Please ensure to label (via GitHub labels) the PR with either patch, minor, or major._
 
 ### Proposed Changes
 _Please use the Jira Key followed by the changes_
@@ -13,6 +12,6 @@ _Please use the Jira Key followed by the changes_
 - [ ] I have added or updated integration tests (if appropriate)
 - [ ] I have added or updated documentation / readme (if appropriate)
 - [ ] I have verified that my changes have not introduced new lint errors
-- [ ] I have updated the change log
+- [ ] I have added a GitHub labels to the PR for either _patch_, `minor`, or **major**
 
 ### Testing Instructions


### PR DESCRIPTION
replace changelog PR checklist item with GitHub label item, both to support automatic releases and changelogs with auto

addresses #87 