### PR TITLE
#CCR-961 Missing the correct labels for the message compose windows in secure share

### DIFF
--- a/lib/components/textEditor/richText.js
+++ b/lib/components/textEditor/richText.js
@@ -27,6 +27,7 @@ class RichText extends Component {
   constructor(props) {
     super(props);
 
+    this.editorWrapRef = React.createRef();
     this.state = {
       editorState: createEditorStateWithText(''),
       settings: (() => {
@@ -75,6 +76,14 @@ class RichText extends Component {
     };
   }
 
+  // eslint-disable-next-line require-jsdoc
+  componentDidMount() {
+    const buttons = this.editorWrapRef.current.querySelectorAll('button');
+    buttons.forEach((button) => {
+      button.setAttribute('tabindex', '-1');
+    });
+  }
+
   focus = () => this.editor.focus();
 
   onChange = (editorState) => {
@@ -86,14 +95,19 @@ class RichText extends Component {
 
   // eslint-disable-next-line require-jsdoc
   render() {
-    const { placeholder } = this.props;
+    const { placeholder, ariaLabel } = this.props;
     const { settings, editorState } = this.state;
 
     const { plugins, Toolbar, TextAlignment, LinkButton, UndoButton, RedoButton } = settings;
     return (
       <>
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-        <div className={styles.editor} onClick={this.focus} data-testid="richText">
+        <div
+          className={styles.editor}
+          onClick={this.focus}
+          data-testid="richText"
+          ref={this.editorWrapRef}
+        >
           <Editor
             editorState={editorState}
             onChange={this.onChange}
@@ -102,6 +116,7 @@ class RichText extends Component {
               this.editor = element;
             }}
             placeholder={placeholder}
+            ariaLabel={ariaLabel}
           />
           <Toolbar>
             {(externalProps) => (
@@ -141,10 +156,12 @@ class RichText extends Component {
 RichText.propTypes = {
   getEditorData: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
+  ariaLabel: PropTypes.string,
 };
 
 RichText.defaultProps = {
   placeholder: '',
+  ariaLabel: '',
 };
 
 export default RichText;

--- a/stories/virtru/sendMessage/basic.jsx
+++ b/stories/virtru/sendMessage/basic.jsx
@@ -79,6 +79,7 @@ storiesOf('virtru/sendMessage', module).add('basic', () => {
             <RichText
               getEditorData={getEditorData}
               placeholder="Encrypted message goes here. Recipient can only view this message after decryption."
+              ariaLabel="Encrypted message"
             />
           </GroupEditor>
           <GroupEditor>


### PR DESCRIPTION
…n secure share


### Proposed Changes
_Please use the Jira Key followed by the changes_

- CCR-961
  - Added the correct labels for the message for rich editor


### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [x] I have added a GitHub labels to the PR for either _patch_, `minor`, or **major**

### Testing Instructions
