### PR TITLE
#CCR-955_5 fixed width column for tablet in layoutOneThird.js

### DIFF
--- a/lib/components/layout/layoutOneThird.js
+++ b/lib/components/layout/layoutOneThird.js
@@ -8,10 +8,10 @@ const LayoutOneThird = ({ left, right }) => {
   return (
     <div className={styles.wrap}>
       <Row gutter={{ xs: 16, sm: 24, md: 42 }}>
-        <Col span={16} xs={24} sm={12} md={16}>
+        <Col span={16} xs={24} sm={12} md={13} lg={16}>
           {left}
         </Col>
-        <Col span={8} xs={24} sm={12} md={8} className={styles.rightCol}>
+        <Col span={8} xs={24} sm={12} md={11} lg={8} className={styles.rightCol}>
           {right}
         </Col>
       </Row>


### PR DESCRIPTION
### Proposed Changes
_Please use the Jira Key followed by the changes_

- CCR-955
  - I fixed the width of column for the tablet in layoutOneThird.js (according to a comment from Jared Crane https://virtru.slack.com/archives/C03H5QUNFM1/p1654100308713099?thread_ts=1654099822.868619&cid=C03H5QUNFM1)

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have added a GitHub labels to the PR for either _patch_, `minor`, or **major**

### Testing Instructions
