### PR TITLE
Version bump: @draft-js-plugins/buttons with latest accessibility updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2001,11 +2001,18 @@
       }
     },
     "@draft-js-plugins/buttons": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@draft-js-plugins/buttons/-/buttons-4.3.0.tgz",
-      "integrity": "sha512-GjE0uorndMO0A9IK2kijoguKFS9eT35PA30xvmjM7wA+kdepXxwT9hcg4CmGE9gKSxm/dDEjUKjQosd9eeNXUQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/buttons/-/buttons-4.3.2.tgz",
+      "integrity": "sha512-KEBp37yCfJDZamAcUHJE0Q1gH2voqt+DMPvzmI2Th6Xz0El/cdcOoAAgX3JPqDzWfd4sc7dDhm/77r9HmO8wIA==",
       "requires": {
-        "clsx": "^1.0.4"
+        "clsx": "^1.2.1"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        }
       }
     },
     "@draft-js-plugins/editor": {

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.6.2",
     "@draft-js-plugins/anchor": "^4.1.3",
-    "@draft-js-plugins/buttons": "^4.3.0",
+    "@draft-js-plugins/buttons": "^4.3.2",
     "@draft-js-plugins/editor": "^4.1.2",
     "@draft-js-plugins/static-toolbar": "^4.1.2",
     "@draft-js-plugins/text-alignment": "^1.0.0",


### PR DESCRIPTION
### Proposed Changes

An update was merged in upstream to add accessibility labels to RichText buttons in the Draft.js buttons plugins repo: https://github.com/draft-js-plugins/draft-js-plugins/pull/2898/files 

This update bumps the version of @draft-js-plugins/buttons to 4.3.2 with the latest changes. 

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [x] I have added a GitHub labels to the PR for either _patch_, `minor`, or **major**

### Testing Instructions
