### PR TITLE
fix(version bump): adds accessibility label to link button for CCR-817

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1989,15 +1989,22 @@
       "dev": true
     },
     "@draft-js-plugins/anchor": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@draft-js-plugins/anchor/-/anchor-4.1.3.tgz",
-      "integrity": "sha512-hcRmoDaavg3orclw7AKpm6cqQ57bl6V7oCvIjQzS5hhXbrzKKSYhNAE0Zy6RbzmBTyZn9+cV0P/SKj5WN9pK8w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/anchor/-/anchor-4.2.0.tgz",
+      "integrity": "sha512-FZXegYNZgAMrU6tesM3SywBKLoxOj7Eae3D9KzJcHx3CF/ldWcbxU3dqV3+OYtP+FFB3wIe2YUGYp+hroaVlkw==",
       "requires": {
         "@draft-js-plugins/utils": "^4.0.0",
-        "clsx": "^1.0.4",
-        "prepend-http": "3",
-        "prop-types": "^15.5.8",
-        "tlds": "^1.221.1"
+        "clsx": "^1.2.1",
+        "prepend-http": "3.0.1",
+        "prop-types": "^15.8.1",
+        "tlds": "^1.231.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        }
       }
     },
     "@draft-js-plugins/buttons": {
@@ -31153,9 +31160,9 @@
       "dev": true
     },
     "tlds": {
-      "version": "1.230.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.230.0.tgz",
-      "integrity": "sha512-QFuY6JBWZt2bZXlapjqsojul5dv9xfo7Uc8wTUlctJOuF+BS/ICni2f4x7MFiT7muUVmcKC1LvGnU4GWhYO0PQ=="
+      "version": "1.231.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.231.0.tgz",
+      "integrity": "sha512-L7UQwueHSkGxZHQBXHVmXW64oi+uqNtzFt2x6Ssk7NVnpIbw16CRs4eb/jmKOZ9t2JnqZ/b3Cfvo97lnXqKrhw=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.6.2",
-    "@draft-js-plugins/anchor": "^4.1.3",
+    "@draft-js-plugins/anchor": "^4.2.0",
     "@draft-js-plugins/buttons": "^4.3.2",
     "@draft-js-plugins/editor": "^4.1.2",
     "@draft-js-plugins/static-toolbar": "^4.1.2",


### PR DESCRIPTION



### Proposed Changes
CCR-817

  - PR to @draft-js-plugins/anchor was approved to add an accessibility aria label to the link button
  - This PR to virtuoso-design-system pulls in that latest change via version bump

### Checklist

- [X] I have added or updated unit tests
- [X] I have added or updated integration tests (if appropriate)
- [X] I have added or updated documentation / readme (if appropriate)
- [X] I have verified that my changes have not introduced new lint errors
- [x] I have added a GitHub labels to the PR for either _patch_, `minor`, or **major**

### Testing Instructions
