### PR TITLE
feat(textEditor): enable spell check by default

### DIFF
--- a/lib/components/textEditor/richText.js
+++ b/lib/components/textEditor/richText.js
@@ -114,7 +114,7 @@ class RichText extends Component {
 
   // eslint-disable-next-line require-jsdoc
   render() {
-    const { placeholder, ariaLabel } = this.props;
+    const { placeholder, ariaLabel, spellCheck } = this.props;
     const { settings, editorState } = this.state;
 
     const { plugins, Toolbar, LinkButton } = settings;
@@ -141,6 +141,7 @@ class RichText extends Component {
                 : ''
             }
             ariaLabel={ariaLabel}
+            spellCheck={spellCheck === false ? false : true}
           />
           <Toolbar>
             {(externalProps) => (
@@ -168,6 +169,7 @@ RichText.propTypes = {
   getEditorData: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
   ariaLabel: PropTypes.string,
+  spellCheck: PropTypes.boolean,
   maxContentSize: PropTypes.shape({
     bytes: PropTypes.number,
     warning: PropTypes.node,
@@ -177,6 +179,7 @@ RichText.propTypes = {
 RichText.defaultProps = {
   placeholder: '',
   ariaLabel: '',
+  spellCheck: true, // Take note of: https://draftjs.org/docs/api-reference-editor/#spellcheck
   maxContentSize: {
     bytes: null,
     warning: null,


### PR DESCRIPTION
Note: https://draftjs.org/docs/api-reference-editor/#spellcheck

Note that in OSX Safari, enabling spellcheck also enables autocorrect, if the user has it turned on. Also note that spellcheck is always disabled in IE, since the events needed to observe spellcheck events are not fired in IE.


### Proposed Changes
_Please use the Jira Key followed by the changes_

- JIRAKEY-1234
  - Some change
  - Another change

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have added a GitHub labels to the PR for either _patch_, `minor`, or **major**

### Testing Instructions
